### PR TITLE
Adding Sass example and other readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pantheon CircleCI Orb
 
+[![CircleCI](https://circleci.com/gh/pantheon-systems/circleci-orb.svg?style=svg)](https://circleci.com/gh/pantheon-systems/circleci-orb)
+
 This reposistory contains the source code for Pantheon's [CircleCI Orb](https://circleci.com/docs/2.0/orb-intro/).
 Orbs are a way of encapsulating sharable CircleCI jobs and commands.
 

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ Those can be copied in one command using the [Terminus Build Tools Plugin](https
    * Sign in to [CircleCI](https://circleci.com/dashboard) and set up the repo for Circle builds.
    * In your local checkout of your code, create a file at `.circleci/config.yml`.
    * Copy this example into the `config.yml` file.
-   ```yml
-      version: 2.1
-      workflows:
-        version: 2
-        just_push:
-          jobs:
-            - pantheon/push
-      orbs:
+        ```yml
+        version: 2.1
+        workflows:
+          version: 2
+          just_push:
+              jobs:
+              - pantheon/push
+        orbs:
         pantheon: pantheon-systems/pantheon@0.0.1
-    ```
+        ```
    * Commit and push the file to GitHub. CircleCI will build attempt to run workflow but it will return an error message because the steps below have not yet been completed. Turning failing red builds into passing green builds is part of the joy of CI.
    * Until this Orb is released as a 1.0.0, you will need to set the "[Allow Uncertified Orbs](https://circleci.com/docs/2.0/orbs-faq/#using-3rd-party-orbs)" option.
 3. Set up SSH keys and environment variables.
@@ -46,14 +46,14 @@ Those can be copied in one command using the [Terminus Build Tools Plugin](https
 Here is the simplest possible usage of this orb in a `.circleci/config.yml` file.
 
 ```yml
-      version: 2.1
-      workflows:
-        version: 2
-        just_push:
-          jobs:
-            - pantheon/push
-      orbs:
-        pantheon: pantheon-systems/pantheon@0.0.1
+version: 2.1
+workflows:
+  version: 2
+  just_push:
+    jobs:
+    - pantheon/push
+orbs:
+  pantheon: pantheon-systems/pantheon@0.0.1
 ```
 
 Here is an example of that includes calling `composer install` before pushing to

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -138,7 +138,7 @@ examples:
           jobs:
             - pantheon/push
       orbs:
-        pantheon: pantheon-systems/pantheon@0.0.1
+        pantheon: pantheon-systems/pantheon@0.0.2
 
   compile_sass_and_push:
     description: |
@@ -172,7 +172,7 @@ examples:
                 # https://github.com/pantheon-systems/example-drops-8-composer/blob/670ae310c601dabbb7b35411ff3e08e4b1fac7a3/composer.json#L67
                 - run: rm wp-content/themes/may2019/.gitignore
       orbs:
-        pantheon: pantheon-systems/pantheon@0.0.1
+        pantheon: pantheon-systems/pantheon@0.0.2
       jobs:
         # This job compiles Sass and then saves (persists) the directory
         # containing the compiled css for reuse in the pantheon/push job.
@@ -182,7 +182,7 @@ examples:
           steps:
           - checkout
           - run:
-              name: Install npm dependencies
+              name: install npm dependencies in a custom WordPress child theme
               command: cd wp-content/themes/may2019 && npm ci
           - run:
               name: Compile Sass

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,9 +9,10 @@ jobs:
     working_directory: ~/sitedir
     environment:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
-      ADMIN_USERNAME: admin
+      # @todo, remove this variable https://github.com/pantheon-systems/circleci-orb/issues/7
       BUILD_TOOLS_VERSION: dev-option-for-no-force
       TERM: dumb
+      PANTHEON_REPO_DIR: "/tmp/pantheon_repo"
     parameters:
       checkout:
         description: "Should this job checkout your repository as the first step? Set to false if you are calling 'checkout' in 'pre-steps'"
@@ -57,7 +58,6 @@ jobs:
       - run:
           name: Checkout site repository from Pantheon
           command: |
-            export PANTHEON_REPO_DIR="/tmp/pantheon_repo_for_$TERMINUS_SITE"
             # Ensure that there's a Pantheon repo locally. If one was not
             # restored from cache, clone it fresh.
             if [ ! -d "$PANTHEON_REPO_DIR/.git" ]; then
@@ -69,9 +69,10 @@ jobs:
             fi
 
             git fetch pantheon
-            REMOTE_REF_TO_ENV=$(git ls-remote pantheon | grep "refs/heads/$TERMINUS_ENV$") || echo "hmm, assigning an empty var returns an error."
-
-            if [ -n "$REMOTE_REF_TO_ENV" ]; then
+            
+            # If the current branch is on Pantheon, check it out.
+            # If it is not, checkout master and then make a new branch.
+            if git ls-remote pantheon | grep "refs/heads/$TERMINUS_ENV$" > /dev/null; then
               git checkout $TERMINUS_ENV
               git pull
             else
@@ -79,10 +80,11 @@ jobs:
               git pull
               git checkout -b $TERMINUS_ENV
             fi
+
       - save_cache:
           key: pantheon-repo-{{ .Branch }}
           paths:
-            - /tmp/pantheon_repo_for_$TERMINUS_SITE
+            - $PANTHEON_REPO_DIR
 
       - run:
           name: Delete old Multidevs to make space for a potential new one
@@ -91,7 +93,6 @@ jobs:
       - run:
           name: Copy code to the local clone of the Pantheon repository
           command: |
-              export PANTHEON_REPO_DIR="/tmp/pantheon_repo_for_$TERMINUS_SITE"
               rsync -av --exclude='.git'  . $PANTHEON_REPO_DIR  --delete
               # For easier debugging, show what files have changed.
               git -C $PANTHEON_REPO_DIR status
@@ -99,7 +100,6 @@ jobs:
       - run:
           name: Commit code to Pantheon repository and push to Pantheon
           command: |
-              export PANTHEON_REPO_DIR="/tmp/pantheon_repo_for_$TERMINUS_SITE"
               # Create a new multidev site to test on
               terminus -n env:wake "$TERMINUS_SITE.dev"
               cd $PANTHEON_REPO_DIR

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -139,3 +139,55 @@ examples:
             - pantheon/push
       orbs:
         pantheon: pantheon-systems/pantheon@0.0.1
+
+  compile_sass_and_push:
+    description: |
+      Compile Sass in a separate job before pushing to Pantheon. See this example in use at https://github.com/stevector/wordpress-orb-demo
+    usage:
+      # See this example in use at https://github.com/stevector/wordpress-orb-demo
+      version: 2.1
+      workflows:
+        version: 2
+        compile_sass_and_push:
+          jobs:
+          - npmbuild_and_persist
+          - pantheon/push:
+              # This "requires" section tells CircleCI the order in which
+              # jobs must be run.
+              requires:
+                - npmbuild_and_persist
+              checkout: false
+              pre-steps:
+                - checkout
+                # Attach this dist directory created in npmbuild_and_persist
+                # which contains the compiled css.
+                - attach_workspace:
+                    at: .
+                # The dist directory that holds the compiled Sass is git ignored.
+                # It needs to be committed on Pantheon.
+                # Removing this .gitignore file makes it available for committing.
+                # Pantheon's Composer examples use a more complicated
+                # technique of "cutting" the top level .gitignore
+                # file so that lines specifying build artifact directories are removed.
+                # https://github.com/pantheon-systems/example-drops-8-composer/blob/670ae310c601dabbb7b35411ff3e08e4b1fac7a3/composer.json#L67
+                - run: rm wp-content/themes/may2019/.gitignore
+      orbs:
+        pantheon: pantheon-systems/pantheon@0.0.1
+      jobs:
+        # This job compiles Sass and then saves (persists) the directory
+        # containing the compiled css for reuse in the pantheon/push job.
+        npmbuild_and_persist:
+          docker:
+          - image: node:10.15.3
+          steps:
+          - checkout
+          - run:
+              name: Install npm dependencies
+              command: cd wp-content/themes/may2019 && npm ci
+          - run:
+              name: Compile Sass
+              command: cd wp-content/themes/may2019 && npm run build
+          - persist_to_workspace:
+              root: .
+              paths:
+              - wp-content/themes/may2019/dist


### PR DESCRIPTION
This contains improvements over yesterday's 0.0.1 release.

- Adding an example workflow that compiles Sass before using the `push` job. The example is copied from this [WordPress Repo configuration](https://github.com/stevector/wordpress-orb-demo/blob/master/.circleci/config.yml).
- Replacing the Composer example in the readme with the Sass example.
- Other Readme fixes.
- Slight simplification of the logic in the "Checkout site repository from Pantheon" command that does not change the end behavior of the job.