### PR TITLE
Add parameter for "Directory to push"

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Jobs from CircleCI Orbs can take parameters (variables) that alter the behavior 
 | `checkout`                 | boolean | `true`        | no       | Determines whether a git checkout will be the first command called by the job. Set to false if you have already called "checkout" in the `pre-steps` section.              |
 | `env_create_max_time`      | string  | `"10m"`       | no       | The maximum amount of time to wait for Pantheon environment creation (terminus -n build:env:create). This parameter maps to CircleCI's native `no_output_timeout` option." |
 | `terminus_clone_env`       | string  | `"live"`      | no       | The source environment from which the database and uploaded files are cloned.                                                                                              |
-| `directory_to_push`        | string  | `"."`         | no       | The directory within the repository to push to Pantheon. Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage a backend CMS on Pantheon and a decoupled frontend deployed elsewhere. |
+| `directory_to_push`        | string  | `"."`         | no       | The directory within the repository to push to Pantheon. Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage a backend CMS on Pantheon and a decoupled frontend deployed elsewhere, set this param to the name of the directory that holds your `pantheon.yml` file. |
 
 ## Assumptions and Intended Audience
 

--- a/README.md
+++ b/README.md
@@ -126,9 +126,10 @@ Jobs from CircleCI Orbs can take parameters (variables) that alter the behavior 
 
 | parameter name             | type    | default value | required | description                                                                                                                                                                |
 |----------------------------|---------|---------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `checkout`                 | boolean | true          | no       | Determines whether a git checkout will be the first command called by the job. Set to false if you have already called "checkout" in the `pre-steps` section.              |
-| `env_create_max_time`      | string  | 10m           | no       | The maximum amount of time to wait for Pantheon environment creation (terminus -n build:env:create). This parameter maps to CircleCI's native `no_output_timeout` option." |
-| `terminus_clone_env`       | string  | live          | no       | The source environment from which the database and uploaded files are cloned.                                                                                              |
+| `checkout`                 | boolean | `true`        | no       | Determines whether a git checkout will be the first command called by the job. Set to false if you have already called "checkout" in the `pre-steps` section.              |
+| `env_create_max_time`      | string  | `"10m"`       | no       | The maximum amount of time to wait for Pantheon environment creation (terminus -n build:env:create). This parameter maps to CircleCI's native `no_output_timeout` option." |
+| `terminus_clone_env`       | string  | `"live"`      | no       | The source environment from which the database and uploaded files are cloned.                                                                                              |
+| `directory_to_push`        | string  | `"."`         | no       | The directory within the repository to push to Pantheon. Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage a backend CMS on Pantheon and a decoupled frontend deployed elsewhere. |
 
 ## Assumptions and Intended Audience
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -15,7 +15,7 @@ jobs:
       PANTHEON_REPO_DIR: "/tmp/pantheon_repo"
     parameters:
       directory_to_push:
-        description: "Which directory within the repository should be pushed to Pantheon. Defaults to the git root: '.' Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage an backend CMS on Pantheon and a decoupled frontend deployed elsewhere."
+        description: "The directory within the repository to push to Pantheon. Defaults to the git root: '.' Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage a backend CMS on Pantheon and a decoupled frontend deployed elsewhere."
         default: "."
         type: string
       checkout:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -97,7 +97,7 @@ jobs:
       - run:
           name: Copy code to the local clone of the Pantheon repository
           command: |
-              rsync -av --exclude='.git'  . $PANTHEON_REPO_DIR  --delete
+              rsync -av --exclude='.git'  << parameters.directory_to_push >> $PANTHEON_REPO_DIR  --delete
               # For easier debugging, show what files have changed.
               git -C $PANTHEON_REPO_DIR status
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -14,6 +14,10 @@ jobs:
       TERM: dumb
       PANTHEON_REPO_DIR: "/tmp/pantheon_repo"
     parameters:
+      directory_to_push:
+        description: "Which directory within the repository should be pushed to Pantheon. Defaults to '.'"
+        default: "."
+        type: string
       checkout:
         description: "Should this job checkout your repository as the first step? Set to false if you are calling 'checkout' in 'pre-steps'"
         default: true

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -15,7 +15,7 @@ jobs:
       PANTHEON_REPO_DIR: "/tmp/pantheon_repo"
     parameters:
       directory_to_push:
-        description: "Which directory within the repository should be pushed to Pantheon. Defaults to '.'"
+        description: "Which directory within the repository should be pushed to Pantheon. Defaults to the git root: '.' Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage an backend CMS on Pantheon and a decoupled frontend deployed elsewhere."
         default: "."
         type: string
       checkout:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -15,7 +15,7 @@ jobs:
       PANTHEON_REPO_DIR: "/tmp/pantheon_repo"
     parameters:
       directory_to_push:
-        description: "The directory within the repository to push to Pantheon. Defaults to the git root: '.' Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage a backend CMS on Pantheon and a decoupled frontend deployed elsewhere."
+        description: "The directory within the repository to push to Pantheon. Defaults to the git root: '.' Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage a backend CMS on Pantheon and a decoupled frontend deployed elsewhere, set this param to the name of the directory that holds your `pantheon.yml` file."
         default: "."
         type: string
       checkout:


### PR DESCRIPTION
The orb currently assumes that the code to be pushed is at the root of the current working directory (the git root). That might not be true if the given repo is a decoupled project with a PHP CMS in one directory and a node/JAM stack codebase in another directory.