### PR TITLE
Update readme for 0.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Jobs from CircleCI Orbs can take parameters (variables) that alter the behavior 
 | `checkout`                 | boolean | `true`        | no       | Determines whether a git checkout will be the first command called by the job. Set to false if you have already called "checkout" in the `pre-steps` section.              |
 | `env_create_max_time`      | string  | `"10m"`       | no       | The maximum amount of time to wait for Pantheon environment creation (terminus -n build:env:create). This parameter maps to CircleCI's native `no_output_timeout` option." |
 | `terminus_clone_env`       | string  | `"live"`      | no       | The source environment from which the database and uploaded files are cloned.                                                                                              |
-| `directory_to_push`        | string  | `"."`         | no       | The directory within the repository to push to Pantheon. Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage a backend CMS on Pantheon and a decoupled frontend deployed elsewhere. |
+| `directory_to_push`        | string  | `"."`         | no       | The directory within the repository to push to Pantheon. Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage a backend CMS on Pantheon and a decoupled frontend deployed elsewhere, set this param to the name of the directory that holds your `pantheon.yml` file. |
 
 ## Assumptions and Intended Audience
 

--- a/README.md
+++ b/README.md
@@ -126,9 +126,10 @@ Jobs from CircleCI Orbs can take parameters (variables) that alter the behavior 
 
 | parameter name             | type    | default value | required | description                                                                                                                                                                |
 |----------------------------|---------|---------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `checkout`                 | boolean | true          | no       | Determines whether a git checkout will be the first command called by the job. Set to false if you have already called "checkout" in the `pre-steps` section.              |
-| `env_create_max_time`      | string  | 10m           | no       | The maximum amount of time to wait for Pantheon environment creation (terminus -n build:env:create). This parameter maps to CircleCI's native `no_output_timeout` option." |
-| `terminus_clone_env`       | string  | live          | no       | The source environment from which the database and uploaded files are cloned.                                                                                              |
+| `checkout`                 | boolean | `true`        | no       | Determines whether a git checkout will be the first command called by the job. Set to false if you have already called "checkout" in the `pre-steps` section.              |
+| `env_create_max_time`      | string  | `"10m"`       | no       | The maximum amount of time to wait for Pantheon environment creation (terminus -n build:env:create). This parameter maps to CircleCI's native `no_output_timeout` option." |
+| `terminus_clone_env`       | string  | `"live"`      | no       | The source environment from which the database and uploaded files are cloned.                                                                                              |
+| `directory_to_push`        | string  | `"."`         | no       | The directory within the repository to push to Pantheon. Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage a backend CMS on Pantheon and a decoupled frontend deployed elsewhere. |
 
 ## Assumptions and Intended Audience
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Those can be copied in one command using the [Terminus Build Tools Plugin](https
               jobs:
               - pantheon/push
         orbs:
-          pantheon: pantheon-systems/pantheon@0.1.0
+          pantheon: pantheon-systems/pantheon@0.2.0
         ```
    * Commit and push the file to GitHub. CircleCI will build attempt to run the workflow but it will return an error message because the steps below have not yet been completed. Turning failing red builds into passing green builds is part of the joy of CI.
    * Set the "[Allow Uncertified Orbs](https://circleci.com/docs/2.0/orbs-faq/#using-3rd-party-orbs)" option to allow Orbs written by those other than CircleCI to be used within your organization. For GitHub users this can be done at `https://circleci.com/gh/organizations/YOUR_USERNAME_OR_ORGNAME/settings#security`
@@ -58,7 +58,7 @@ workflows:
     jobs:
     - pantheon/push
 orbs:
-  pantheon: pantheon-systems/pantheon@0.1.0
+  pantheon: pantheon-systems/pantheon@0.2.0
 ```
 
 Here is an example that compiles Sass in a separate job before pushing to Pantheon.
@@ -99,7 +99,7 @@ workflows:
           - run: rm wp-content/themes/may2019/.gitignore
 
 orbs:
-  pantheon: pantheon-systems/pantheon@0.1.0
+  pantheon: pantheon-systems/pantheon@0.2.0
 jobs:
   # This job compiles Sass and then saves (persists) the directory
   # containing the compiled css for reuse in the pantheon/push job.

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -15,7 +15,7 @@ jobs:
       PANTHEON_REPO_DIR: "/tmp/pantheon_repo"
     parameters:
       directory_to_push:
-        description: "Which directory within the repository should be pushed to Pantheon. Defaults to the git root: '.' Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage an backend CMS on Pantheon and a decoupled frontend deployed elsewhere."
+        description: "The directory within the repository to push to Pantheon. Defaults to the git root: '.' Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage a backend CMS on Pantheon and a decoupled frontend deployed elsewhere."
         default: "."
         type: string
       checkout:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -97,7 +97,7 @@ jobs:
       - run:
           name: Copy code to the local clone of the Pantheon repository
           command: |
-              rsync -av --exclude='.git'  . $PANTHEON_REPO_DIR  --delete
+              rsync -av --exclude='.git'  << parameters.directory_to_push >> $PANTHEON_REPO_DIR  --delete
               # For easier debugging, show what files have changed.
               git -C $PANTHEON_REPO_DIR status
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -14,6 +14,10 @@ jobs:
       TERM: dumb
       PANTHEON_REPO_DIR: "/tmp/pantheon_repo"
     parameters:
+      directory_to_push:
+        description: "Which directory within the repository should be pushed to Pantheon. Defaults to '.'"
+        default: "."
+        type: string
       checkout:
         description: "Should this job checkout your repository as the first step? Set to false if you are calling 'checkout' in 'pre-steps'"
         default: true

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -15,7 +15,7 @@ jobs:
       PANTHEON_REPO_DIR: "/tmp/pantheon_repo"
     parameters:
       directory_to_push:
-        description: "Which directory within the repository should be pushed to Pantheon. Defaults to '.'"
+        description: "Which directory within the repository should be pushed to Pantheon. Defaults to the git root: '.' Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage an backend CMS on Pantheon and a decoupled frontend deployed elsewhere."
         default: "."
         type: string
       checkout:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -15,7 +15,7 @@ jobs:
       PANTHEON_REPO_DIR: "/tmp/pantheon_repo"
     parameters:
       directory_to_push:
-        description: "The directory within the repository to push to Pantheon. Defaults to the git root: '.' Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage a backend CMS on Pantheon and a decoupled frontend deployed elsewhere."
+        description: "The directory within the repository to push to Pantheon. Defaults to the git root: '.' Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage a backend CMS on Pantheon and a decoupled frontend deployed elsewhere, set this param to the name of the directory that holds your `pantheon.yml` file."
         default: "."
         type: string
       checkout:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -184,7 +184,7 @@ examples:
                 # https://github.com/pantheon-systems/example-drops-8-composer/blob/670ae310c601dabbb7b35411ff3e08e4b1fac7a3/composer.json#L67
                 - run: rm wp-content/themes/may2019/.gitignore
       orbs:
-        pantheon: pantheon-systems/pantheon@0.1.0
+        pantheon: pantheon-systems/pantheon@0.2.0
       jobs:
         # This job compiles Sass and then saves (persists) the directory
         # containing the compiled css for reuse in the pantheon/push job.


### PR DESCRIPTION
Draft of 0.2.0 release notes:

-----------------------------------------

The 0.2.0 release is a *minor* release because it contains functionality enhancements:

* PR https://github.com/pantheon-systems/circleci-orb/pull/32 from @stevector adds the param `env_create_max_time` to avoid timeouts on slow multidev creation.
* PR https://github.com/pantheon-systems/circleci-orb/pull/33 from `@nullvariable` also can address slow multidev creation by adding the `terminus_clone_env` param to set which environment is used as the source for database and uploaded file cloning. Rather than cloning the entire Live, database the source could be a different multidev where the database has been truncated to some degree. 
* PR https://github.com/pantheon-systems/circleci-orb/pull/36 from @stevector adds the `directory_to_push` param to allow a repo to use a more complex structure where `pantheon.yml` is somewhere other than the git root. This feature was added for decoupled applications where backend and frontend codebases will be kept in different subdirectories.

The `0.2.0` tag also contains patch-release level fixes in documentation

* PR https://github.com/pantheon-systems/circleci-orb/pull/31 from @stevector corrects the README file to state that the `Allow Uncertified Orbs` option is needed for any 3rd party orb, including this one.

