### PR TITLE
trying to fix subdirectory bug

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -105,7 +105,7 @@ jobs:
       - run:
           name: Copy code to the local clone of the Pantheon repository
           command: |
-              rsync -av --exclude='.git'  << parameters.directory_to_push >> $PANTHEON_REPO_DIR  --delete
+              rsync -av --exclude='.git'  << parameters.directory_to_push >>/ $PANTHEON_REPO_DIR  --delete
               # For easier debugging, show what files have changed.
               git -C $PANTHEON_REPO_DIR status
 


### PR DESCRIPTION
This change fixes a bug in #36 which required a trailing slash to be included in the parameter.