### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,7 +1,9 @@
 version: 2.1
 description: |
-  Use CircleCI to push code to Pantheon Dev and Multidev Environments. Maintained at https://github.com/pantheon-systems/circleci-orb
-
+  Use CircleCI to push code to Pantheon Dev and Multidev Environments.
+display:
+  source_url: https://github.com/pantheon-systems/circleci-orb
+  home_url: https://pantheon.io/
 jobs:
   push:
     docker:


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.