### PR TITLE
Allow env vars to be set in pre-steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Jobs from CircleCI Orbs can take parameters (variables) that alter the behavior 
 | `env_create_max_time`      | string  | `"10m"`       | no       | The maximum amount of time to wait for Pantheon environment creation (terminus -n build:env:create). This parameter maps to CircleCI's native `no_output_timeout` option." |
 | `terminus_clone_env`       | string  | `"live"`      | no       | The source environment from which the database and uploaded files are cloned.                                                                                              |
 | `directory_to_push`        | string  | `"."`         | no       | The directory within the repository to push to Pantheon. Use this setting if you have a more complex repo structure that puts your Pantheon root in a deeper directory. For instance, if you are using a monorepo to manage a backend CMS on Pantheon and a decoupled frontend deployed elsewhere, set this param to the name of the directory that holds your `pantheon.yml` file. |
+| `set_env_vars`       | boolean  | `true`      | no       | Should this job run a script to set env vars like TERMINUS_ENV? Set to false if you set variables in 'pre-steps'                                                |
 
 ## Assumptions and Intended Audience
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,7 +7,7 @@ display:
 jobs:
   push:
     docker:
-    - image: quay.io/pantheon-public/build-tools-ci:5.x
+    - image: quay.io/pantheon-public/build-tools-ci:6.x
     working_directory: ~/sitedir
     environment:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -24,6 +24,10 @@ jobs:
         description: "Should this job checkout your repository as the first step? Set to false if you are calling 'checkout' in 'pre-steps'"
         default: true
         type: boolean
+      set_env_vars:
+        description: "Should this job run a script to set env vars? Set to false if you set variables in 'presteps'"
+        default: true
+        type: boolean
       env_create_max_time:
         description: "The maximum amount of time to wait for Pantheon environment creation (terminus -n build:env:create). This parameter maps to CircleCI's native 'no_output_timeout' option."
         default: "10m"
@@ -49,9 +53,12 @@ jobs:
       # will be the Multidev environment pr-$CI_PULL_REQUEST
       # In all other cases a new Pantheon multidev will be created specifically
       # for this build number, ci-$CIRCLE_BUILD_NUM.
-      - run:
-          name: Derive additional environment variables
-          command: /build-tools-ci/scripts/set-environment
+      - when:
+          condition: <<parameters.set_env_vars>>
+          steps:
+            - run:
+                name: Derive additional environment variables
+                command: /build-tools-ci/scripts/set-environment
 
       # Later commands require being signed in to Pantheon.
       - run:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -25,7 +25,7 @@ jobs:
         default: true
         type: boolean
       set_env_vars:
-        description: "Should this job run a script to set env vars? Set to false if you set variables in 'presteps'"
+        description: "Should this job run a script to set env vars like TERMINUS_ENV? Set to false if you set variables in 'pre-steps'"
         default: true
         type: boolean
       env_create_max_time:


### PR DESCRIPTION
We have a use case where TERMINUS_ENV needs to be overridden to create a different multidev name. This PR adds a boolean parameter so that `/build-tools-ci/scripts/set-environment` can be called earlier or overridden.