### PR TITLE
removing extra terminus build:env:delete

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -178,7 +178,6 @@ jobs:
               # This command will commit any changed files and push to Pantheon.
               # New multidevs will be created as necessary.
               terminus -n build:env:create "$TERMINUS_SITE.<< parameters.terminus_clone_env >>" "$TERMINUS_ENV" --yes $CLONE_CONTENT --message="CI: $COMMIT_MSG"
-
       # @todo, Check back with CircleCI DevRel team. They mentioned possibly
       # adding a CircleCI-maintained Orb step to do this concept.
       - run:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -178,16 +178,7 @@ jobs:
               # This command will commit any changed files and push to Pantheon.
               # New multidevs will be created as necessary.
               terminus -n build:env:create "$TERMINUS_SITE.<< parameters.terminus_clone_env >>" "$TERMINUS_ENV" --yes $CLONE_CONTENT --message="CI: $COMMIT_MSG"
-      - run:
-          name: Delete Multidev environments made for now-closed pull requests
-          command: |
-            # Because this step is slow it should be run more than necessary.
-            if [[ $CI_BRANCH != "master" ]] ; then
-              exit 0
-            fi
-            # Delete old multidev environments associated with a PR that has been
-            # merged or closed.
-            terminus -n build:env:delete:pr "$TERMINUS_SITE" --yes
+
       # @todo, Check back with CircleCI DevRel team. They mentioned possibly
       # adding a CircleCI-maintained Orb step to do this concept.
       - run:


### PR DESCRIPTION
This is a follow up to https://github.com/pantheon-systems/circleci-orb/pull/43. The removal of this call should have also been in #43.