### PR TITLE
Adding CIRCLE_REPOSITORY_URL as origin for full repo for 51 bug fix

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -106,6 +106,9 @@ jobs:
               cd $PANTHEON_REPO_DIR
               git init
               git remote add pantheon $(terminus connection:info $TERMINUS_SITE.dev --field=git_url)
+              # Make the BitBucket or GitHub url be the origin so that Build Tools sets
+              # that url appropriately in the metadata file.
+              git remote add origin $CIRCLE_REPOSITORY_URL
               git remote -v
             fi
 


### PR DESCRIPTION
This PR is meant to address #51. As best I can tell, the way I wrote the Orb to use two repos within it's build process (a clone from Pantheon in addition to the clone from GitHub/BitBucket that comes by default in CI) had the side effect of leaving the `url` key empty in the `build-metadata.json` file.

I think I didn't notice this problem earlier because the real repos that I use the Orb with are repos that pre-date the Orb and the clean-up process called out in the #51 bug report only needs to find one environment with the `url` value set.

Anyway, this change seems good to merge but I'd like validation from at least one tester in #51. See this PR for an example of how to test this particular Orb revision: https://github.com/stevector/nerdologues-d8/pull/373/files