### PR TITLE
#70: Allow user to override rsync options [FEAT-1348]

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -109,6 +109,10 @@ jobs:
         description: "Determines whether or not every build will re-clone content from the environment set in terminus_clone_env. Set to false if cloning the database and files means builds are taking too long."
         default: true
         type: boolean
+      rsync_opts:
+        description: "Options to pass to the rsync command when copying site source into the Pantheon repository to prepare for commit and deploy."
+        default: "--delete"
+        type: string
 
     executor:
       name: default
@@ -212,7 +216,7 @@ jobs:
       - run:
           name: Copy code to the local clone of the Pantheon repository
           command: |
-              rsync -av --exclude='.git'  << parameters.directory_to_push >>/ $PANTHEON_REPO_DIR  --delete
+              rsync -av --exclude='.git'  << parameters.directory_to_push >>/ $PANTHEON_REPO_DIR  << parameters.rsync_opts >>
               # For easier debugging, show what files have changed.
               git -C $PANTHEON_REPO_DIR status
 


### PR DESCRIPTION
Resolves #70

This seemed like the simplest way to carry this out but I'd like to test it to ensure the behavior works as expected. It should also allow folks to pass other rsync flags if they desire. In my test case I intend to pass null/false, I'll report back on how using these steps verbatim performs on our repo before we should consider a merge.