### PR TITLE
71: Add parameter to make multidev cleanup optional

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -109,6 +109,10 @@ jobs:
         description: "Determines whether or not every build will re-clone content from the environment set in terminus_clone_env. Set to false if cloning the database and files means builds are taking too long."
         default: true
         type: boolean
+      cleanup_envs:
+        description: "Determines whether or not old multidev environments will be cleaned up automatically."
+        default: true
+        type: boolean
 
     executor:
       name: default
@@ -182,32 +186,35 @@ jobs:
       # terminus build:env:delete can take around a minute.
       # So only run it when the current build needs to
       # make a new Multidev environment.
-      - run:
-          name: Delete old Multidevs if this build needs to create a new one
-          command: |
-            if [[ $TERMINUS_ENV = ci-* || $TERMINUS_ENV = pr-*   ]]
-            then
-                echo "May need to delete old ci- or pr- environments to make room for this one"
-                echo "Getting list of all environments"
-                export ENV_LIST=$(terminus env:list $TERMINUS_SITE --field=id)
-                echo "Checking if current environment is in list of existing environments"
-                if [[ $(echo "${ENV_LIST}" | grep -x ${TERMINUS_ENV})  ]]
-                then
-                    echo "${TERMINUS_ENV} found in the list of environments"
-                    exit 0
-                else
-                    echo "${TERMINUS_ENV} not found in the list of environments."
-                    echo "Running clean-up script to delete old pr- environments"
-                    terminus -n build:env:delete:pr "$TERMINUS_SITE" --yes
-                    if [[ $TERMINUS_ENV = ci-*  ]]
-                    then
-                        echo "Running clean-up script to delete old ci- environments"
-                        terminus -n build:env:delete:ci "$TERMINUS_SITE" --keep=2 --yes
-                    else
-                        echo "Skipping deletion of ci- envs"
-                    fi
-                fi
-            fi
+      - when:
+          condition: <<parameters.cleanup_envs>>
+          steps:
+            - run:
+                name: Delete old Multidevs if this build needs to create a new one
+                command: |
+                  if [[ $TERMINUS_ENV = ci-* || $TERMINUS_ENV = pr-*   ]]
+                  then
+                      echo "May need to delete old ci- or pr- environments to make room for this one"
+                      echo "Getting list of all environments"
+                      export ENV_LIST=$(terminus env:list $TERMINUS_SITE --field=id)
+                      echo "Checking if current environment is in list of existing environments"
+                      if [[ $(echo "${ENV_LIST}" | grep -x ${TERMINUS_ENV})  ]]
+                      then
+                          echo "${TERMINUS_ENV} found in the list of environments"
+                          exit 0
+                      else
+                          echo "${TERMINUS_ENV} not found in the list of environments."
+                          echo "Running clean-up script to delete old pr- environments"
+                          terminus -n build:env:delete:pr "$TERMINUS_SITE" --yes
+                          if [[ $TERMINUS_ENV = ci-*  ]]
+                          then
+                              echo "Running clean-up script to delete old ci- environments"
+                              terminus -n build:env:delete:ci "$TERMINUS_SITE" --keep=2 --yes
+                          else
+                              echo "Skipping deletion of ci- envs"
+                          fi
+                      fi
+                  fi
 
       - run:
           name: Copy code to the local clone of the Pantheon repository


### PR DESCRIPTION
GIven that #71 was going to be more involved than I anticipated, I've pivoted to just making multidev cleanup optional. This should assuage the greatest fears of a multidev being prematurely deleted, we're going to re-evaluate trying to maintain a custom multidev naming scheme as it's pretty clear that is going to involve a deeper change to Build Tools itself.